### PR TITLE
Fix false positives for `@import` detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function detective(content, options = {}) {
       return;
     }
 
-    if (options?.url && node.type === 'uri') {
+    if (options.url && node.type === 'uri') {
       dependencies = [...dependencies, ...extractDependencies(node, ['string', 'ident', 'raw'])];
     }
   });

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function isImportStatement(node) {
 
   if (atKeyword.content.length === 0) return false;
 
-  return ['ident', 'import'].includes(atKeyword.content[0].type);
+  return atKeyword.content[0].content === 'import';
 }
 
 function extractDependencies(importStatementNode) {

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,10 @@ lessSuite('handles comma-separated imports (#2)', () => {
   test('@import "_foo.less"\n@import "_bar.less"', ['_foo.less', '_bar.less']);
 });
 
+lessSuite('ignores non-import atrules', () => {
+  test('body { @media print { color: blue; } }', []);
+});
+
 lessSuite('returns the url dependencies when enable url', () => {
   test(
     '@font-face { font-family: "Trickster"; src: local("Trickster"), url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1), url("trickster-outline.otf") format("opentype"), url("trickster-outline.woff") format("woff"); }',


### PR DESCRIPTION
The detective was matching things like `@media` queries and `@keyframes` when looking for imports. This updates it to specifically match `@import`s. Thanks!